### PR TITLE
chore: update GitHub Actions to latest commit SHA

### DIFF
--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -35,8 +35,8 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
-        # aka docker/login-action@v3.1.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        # aka docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -44,16 +44,16 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
-        # aka docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
+        # aka docker/metadata-action@v5.6.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
-        # aka docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc
+        # aka docker/build-push-action@v6.11.0
         with:
           context: ./extract
           file: ./extract/Dockerfile

--- a/.github/workflows/gcloud-k9s.yml
+++ b/.github/workflows/gcloud-k9s.yml
@@ -35,8 +35,8 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
-        # aka docker/login-action@v3.1.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        # aka docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -44,16 +44,16 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
-        # aka docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
+        # aka docker/metadata-action@v5.6.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=match,pattern=gcloud-k9s-v(.*),group=1
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
-        # aka docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc
+        # aka docker/build-push-action@v6.11.0
         with:
           context: ./gcloud-k9s
           file: ./gcloud-k9s/Dockerfile


### PR DESCRIPTION
    - update docker/login-action to v3.3.0
    - update docker/metadata-action to v5.6.1
    - update docker/build-push-action to v6.11.0